### PR TITLE
Utilise DateOnly for entity properties that don't contain time values

### DIFF
--- a/example/Forecast.Viewer/Program.cs
+++ b/example/Forecast.Viewer/Program.cs
@@ -94,10 +94,11 @@ public static class Program
                                             .Distinct()
                                             .Select( p => client.GetMilestonesAsync( new MilestoneFilter {ProjectId = p} ).AsTask() );
 
-            var milestoneLimit = DateTime.Today + TimeSpan.FromDays( 14 );
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var milestoneLimit = today.AddDays(14);
             var milestones = ( await Task.WhenAll( milestoneTasks ) )
                             .SelectMany( m => m )
-                            .Where( m => m.Date >= DateTime.Today && m.Date <= milestoneLimit )
+                            .Where( m => m.Date >= today && m.Date <= milestoneLimit )
                             .ToList();
 
             if ( milestones.Any() )

--- a/src/HarvestForecast.Client/DateUtility.cs
+++ b/src/HarvestForecast.Client/DateUtility.cs
@@ -7,7 +7,7 @@ internal static class DateUtility
 {
     public const string DateOnlyFormat = "yyyy-MM-dd";
 
-    public static string FormatDateOnly( DateTime value )
+    public static string FormatDateOnly( DateOnly value )
     {
         return value.ToString( DateOnlyFormat, CultureInfo.InvariantCulture );
     }

--- a/src/HarvestForecast.Client/Entities/Assignment.cs
+++ b/src/HarvestForecast.Client/Entities/Assignment.cs
@@ -23,10 +23,10 @@ public record Assignment( [ property : JsonPropertyName( "id" ) ]
                           int Id,
                           [ property : JsonPropertyName( "start_date" ) ]
                           [ property : JsonConverter( typeof( LocalNullableDateOnlyConverter ) ) ]
-                          DateTime? StartDate,
+                          DateOnly? StartDate,
                           [ property : JsonPropertyName( "end_date" ) ]
                           [ property : JsonConverter( typeof( LocalNullableDateOnlyConverter ) ) ]
-                          DateTime? EndDate,
+                          DateOnly? EndDate,
                           [ property : JsonPropertyName( "allocation" ) ]
                           [ property : JsonConverter( typeof( SecondsToNullableTimeSpanConverter ) ) ]
                           TimeSpan? Allocation,

--- a/src/HarvestForecast.Client/Entities/AssignmentFilter.cs
+++ b/src/HarvestForecast.Client/Entities/AssignmentFilter.cs
@@ -7,7 +7,7 @@ namespace HarvestForecast.Client.Entities;
 /// <summary>
 ///     Filter options for querying <see cref="Assignment" />s.
 /// </summary>
-public record AssignmentFilter( DateTime StartDate, DateTime EndDate ) : DateRangeFilter( StartDate, EndDate )
+public record AssignmentFilter( DateOnly StartDate, DateOnly EndDate ) : DateRangeFilter( StartDate, EndDate )
 {
     /// <summary>
     ///     The ID of the project to filter assignments by.
@@ -34,7 +34,8 @@ public record AssignmentFilter( DateTime StartDate, DateTime EndDate ) : DateRan
     /// </summary>
     public static AssignmentFilter Today()
     {
-        return new AssignmentFilter( DateTime.Today, DateTime.Today );
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        return new AssignmentFilter( today, today );
     }
 
     internal override IEnumerable<KeyValuePair<string, string?>> GetFilters()

--- a/src/HarvestForecast.Client/Entities/DateRangeFilter.cs
+++ b/src/HarvestForecast.Client/Entities/DateRangeFilter.cs
@@ -6,17 +6,17 @@ namespace HarvestForecast.Client.Entities;
 /// <summary>
 ///     A <see cref="FilterBase" /> implementation for filters that require a start and end date.
 /// </summary>
-public record DateRangeFilter( DateTime StartDate, DateTime EndDate ) : FilterBase
+public record DateRangeFilter( DateOnly StartDate, DateOnly EndDate ) : FilterBase
 {
     /// <summary>
     ///     The date to filter assignments from (inclusive).
     /// </summary>
-    public DateTime StartDate { get; } = StartDate;
+    public DateOnly StartDate { get; } = StartDate;
 
     /// <summary>
     ///     The date to filter assignments to (inclusive).
     /// </summary>
-    public DateTime EndDate { get; } = EndDate;
+    public DateOnly EndDate { get; } = EndDate;
 
     internal override IEnumerable<KeyValuePair<string, string?>> GetFilters()
     {

--- a/src/HarvestForecast.Client/Entities/Milestone.cs
+++ b/src/HarvestForecast.Client/Entities/Milestone.cs
@@ -13,7 +13,7 @@ public record Milestone( [ property : JsonPropertyName( "id" ) ]
                          string Name,
                          [ property : JsonPropertyName( "date" ) ] 
                          [ property : JsonConverter( typeof( LocalDateOnlyConverter ) ) ]
-                         DateTime Date,
+                         DateOnly Date,
                          [ property : JsonPropertyName( "updated_at" ) ]
                          DateTimeOffset UpdatedAt ,
                          [ property : JsonPropertyName( "updated_by_id" ) ]

--- a/src/HarvestForecast.Client/Entities/Project.cs
+++ b/src/HarvestForecast.Client/Entities/Project.cs
@@ -18,10 +18,10 @@ public record Project( [ property : JsonPropertyName( "id" ) ]
                        string Code,
                        [ property : JsonPropertyName( "start_date" ) ]
                        [ property : JsonConverter( typeof( LocalNullableDateOnlyConverter ) ) ]
-                       DateTime? StartDate,
+                       DateOnly? StartDate,
                        [ property : JsonPropertyName( "end_date" ) ]
                        [ property : JsonConverter( typeof( LocalNullableDateOnlyConverter ) ) ]
-                       DateTime? EndDate,
+                       DateOnly? EndDate,
                        [ property : JsonPropertyName( "notes" ) ]
                        string? Notes ,
                        [ property : JsonPropertyName( "harvest_id" ) ]

--- a/src/HarvestForecast.Client/HarvestForecast.Client.csproj
+++ b/src/HarvestForecast.Client/HarvestForecast.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/HarvestForecast.Client/Json/DateConversion.cs
+++ b/src/HarvestForecast.Client/Json/DateConversion.cs
@@ -6,7 +6,7 @@ namespace HarvestForecast.Client.Json;
 
 internal static class DateConversion
 {
-    public static DateTime? Read( ref Utf8JsonReader reader )
+    public static DateOnly? Read( ref Utf8JsonReader reader )
     {
         string? raw = reader.GetString();
 
@@ -15,10 +15,10 @@ internal static class DateConversion
             return null;
         }
 
-        return DateTime.ParseExact( raw, DateUtility.DateOnlyFormat, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal );
+        return DateOnly.ParseExact( raw, DateUtility.DateOnlyFormat, CultureInfo.InvariantCulture );
     }
 
-    public static void Write( Utf8JsonWriter writer, DateTime? value )
+    public static void Write( Utf8JsonWriter writer, DateOnly? value )
     {
         if ( value.HasValue )
         {

--- a/src/HarvestForecast.Client/Json/DateOnlyConverter.cs
+++ b/src/HarvestForecast.Client/Json/DateOnlyConverter.cs
@@ -7,14 +7,14 @@ namespace HarvestForecast.Client.Json;
 /// <summary>
 ///     A converter that only writes the <see cref="DateTime.Date" /> part of a <see cref="DateTime" /> value.
 /// </summary>
-internal class LocalDateOnlyConverter : JsonConverter<DateTime>
+internal class LocalDateOnlyConverter : JsonConverter<DateOnly>
 {
-    public override DateTime Read( ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options )
+    public override DateOnly Read( ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options )
     {
         return DateConversion.Read( ref reader )!.Value;
     }
 
-    public override void Write( Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options )
+    public override void Write( Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options )
     {
         DateConversion.Write( writer, value );
     }

--- a/src/HarvestForecast.Client/Json/LocalNullableDateOnlyConverter.cs
+++ b/src/HarvestForecast.Client/Json/LocalNullableDateOnlyConverter.cs
@@ -7,14 +7,14 @@ namespace HarvestForecast.Client.Json;
 /// <summary>
 ///     A converter that only writes the <see cref="DateTime.Date" /> part of a <see cref="DateTime" /> value.
 /// </summary>
-internal class LocalNullableDateOnlyConverter : JsonConverter<DateTime?>
+internal class LocalNullableDateOnlyConverter : JsonConverter<DateOnly?>
 {
-    public override DateTime? Read( ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options )
+    public override DateOnly? Read( ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options )
     {
         return DateConversion.Read( ref reader );
     }
 
-    public override void Write( Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options )
+    public override void Write( Utf8JsonWriter writer, DateOnly? value, JsonSerializerOptions options )
     {
         DateConversion.Write( writer, value );
     }

--- a/test/HarvestForecast.Client.Test/AssignmentTests.cs
+++ b/test/HarvestForecast.Client.Test/AssignmentTests.cs
@@ -22,8 +22,8 @@ public class AssignmentTests
 
         var first = assignments.First();
         Assert.Equal( 1000001, first.Id );
-        Assert.Equal( new DateTime( 2017, 05, 24 ), first.StartDate );
-        Assert.Equal( new DateTime( 2017, 05, 29 ), first.EndDate );
+        Assert.Equal( new DateOnly( 2017, 05, 24 ), first.StartDate );
+        Assert.Equal( new DateOnly( 2017, 05, 29 ), first.EndDate );
         Assert.Null( first.Allocation );
         Assert.Null( first.Notes );
         Assert.Equal( DateTime.Parse( "2017-05-02T19:07:00.478Z" ), first.UpdatedAt );
@@ -37,7 +37,7 @@ public class AssignmentTests
     [ Fact ]
     public void CanFilterByDates()
     {
-        var today = DateTime.Today;
+        var today = DateOnly.FromDateTime(DateTime.Today);
 
         var filter = new AssignmentFilter( today, today );
         var filters = filter.GetActiveFilters().ToList();
@@ -51,7 +51,7 @@ public class AssignmentTests
     [ Fact ]
     public void CanFilterByProjectId()
     {
-        var today = DateTime.Today;
+        var today = DateOnly.FromDateTime(DateTime.Today);
         const int projectId = 567823;
         
         var filter = new AssignmentFilter( today, today )
@@ -67,7 +67,7 @@ public class AssignmentTests
     [ Fact ]
     public void CanFilterByPersonId()
     {
-        var today = DateTime.Today;
+        var today = DateOnly.FromDateTime(DateTime.Today);
         const int personId = 564523;
         
         var filter = new AssignmentFilter( today, today )
@@ -83,7 +83,7 @@ public class AssignmentTests
     [ Fact ]
     public void CanFilterByRepeatedAssignmentSetId()
     {
-        var today = DateTime.Today;
+        var today = DateOnly.FromDateTime(DateTime.Today);
         const int repeatedAssignmentSetId = 23;
         
         var filter = new AssignmentFilter( today, today )
@@ -99,7 +99,7 @@ public class AssignmentTests
     [ Fact ]
     public void CanFilterByState()
     {
-        var today = DateTime.Today;
+        var today = DateOnly.FromDateTime(DateTime.Today);
         
         var filter = new AssignmentFilter( today, today )
         {

--- a/test/HarvestForecast.Client.Test/MilestoneTests.cs
+++ b/test/HarvestForecast.Client.Test/MilestoneTests.cs
@@ -21,7 +21,7 @@ public class MilestoneTests
         var first = milestones.First();
         Assert.Equal( 1100000, first.Id );
         Assert.Equal( "Target Start Date", first.Name );
-        Assert.Equal( new DateTime( 2017, 10, 23 ), first.Date );
+        Assert.Equal( new DateOnly( 2017, 10, 23 ), first.Date );
         Assert.Equal( DateTime.Parse( "2017-08-17T17:28:13.055Z" ), first.UpdatedAt );
         Assert.Equal( 111111, first.UpdatedById );
         Assert.Equal( 2222222, first.ProjectId );

--- a/test/HarvestForecast.Client.Test/ProjectTests.cs
+++ b/test/HarvestForecast.Client.Test/ProjectTests.cs
@@ -24,8 +24,8 @@ public class ProjectTests
         Assert.Equal( "black", first.Color );
         Assert.Null( first.Code );
         Assert.Null( first.Notes );
-        Assert.Equal( new DateTime( 2017, 01, 05 ), first.StartDate );
-        Assert.Equal( new DateTime( 2018, 02, 23 ), first.EndDate );
+        Assert.Equal( new DateOnly( 2017, 01, 05 ), first.StartDate );
+        Assert.Equal( new DateOnly( 2018, 02, 23 ), first.EndDate );
         Assert.Null( first.HarvestId );
         Assert.False( first.Archived );
         Assert.Equal( DateTime.Parse( "2017-10-13T20:49:36.418Z" ), first.UpdatedAt );


### PR DESCRIPTION
This is a breaking change and will remove support for .NET versions less than 6.0